### PR TITLE
Only return public zones

### DIFF
--- a/client.go
+++ b/client.go
@@ -122,7 +122,9 @@ func (p *Provider) getCloudDNSZone(zone string) (string, error) {
 		zonesLister := p.service.ManagedZones.List(p.Project)
 		err := zonesLister.Pages(context.Background(), func(response *dns.ManagedZonesListResponse) error {
 			for _, zone := range response.ManagedZones {
-				p.zoneMap[zone.DnsName] = zone.Name
+				if zone.Visibility == "public" {
+					p.zoneMap[zone.DnsName] = zone.Name
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
There are situations where you can have two different Cloud DNS zones
for the same DNS name, eg:
- one public zone used for DNS delegation
- one private zone used for internal resolution

During DNS challenge for ACME validation process with the following
[ module](https://github.com/caddy-dns/googleclouddns),
if the private zone is returned by libdns/googleclouddns,
then the TXT entry will be created in the private zone,
and will never be publicly resolved.

This PR adds a filtering on `public` zones to avoid pushing TXT entries
to private zones.